### PR TITLE
Add missing execute statement permission and RDS example

### DIFF
--- a/lib/role.js
+++ b/lib/role.js
@@ -115,6 +115,7 @@ const createServiceRole = async (awsIamRole, config, debug) => {
               Action: [
                 'rds-data:DeleteItems',
                 'rds-data:ExecuteSql',
+                'rds-data:ExecuteStatement',
                 'rds-data:GetItems',
                 'rds-data:InsertItems',
                 'rds-data:UpdateItems'


### PR DESCRIPTION
This PR adds missing `rds-data:ExecuteStatement` permission to the generated role