### PR TITLE
Add case for HTTP data source for role creation.

### DIFF
--- a/lib/role.js
+++ b/lib/role.js
@@ -150,6 +150,8 @@ const createServiceRole = async (awsIamRole, config, debug) => {
               )
             }
           ]
+        case 'HTTP':
+          return []
         default:
           break
       }


### PR DESCRIPTION
At present AppSync only supports public HTTP data sources (for which IAM roles are unnecessary). This updated HTTP case makes it so that HTTP-only AppSync components don't have a role while those with other data sources will simply ignore the blank HTTP return. This change is necessary because previously HTTP types would create roles with undefined policies that threw errors on build.