### PR TITLE
Fix dbClusterIdentifier sample value in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,7 +604,7 @@ myAppSyncApi:
         config:
           awsSecretStoreArn: 'arn:aws:secretsmanager:us-east-1:123456789123:secret:rds-db-credentials/cluster-ABCDEFGHI/admin-aBc1e2'
           databaseName: 'mydatabase'
-          dbClusterIdentifier: 'arn:aws:rds:us-east-1:123456789123:cluster:my-serverless-aurora-postgres-1'
+          dbClusterIdentifier: 'my-serverless-aurora-postgres-1'
           schema: 'public'
 
     mappingTemplates:


### PR DESCRIPTION
The example value for `dbClusterIdentifier` in the README is an ARN rather than a cluster name. This means it doesn't fit the [variable definition](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html) and ultimately generates a bad ARN for the AppSync role ( `arn:aws:rds:us-east-1:123456789123:cluster:arn:aws:rds:us-east-1:123456789123:cluster:my-serverless-aurora-postgres-1`).

The updated example will generate a correct ARN when deployed. I know this doesn't alter any functioning code but it should make the guide easier to follow for anyone replacing template values with their own resources.