### PR TITLE
fix ConcurrentModificationException

### DIFF
--- a/lib/datasources.js
+++ b/lib/datasources.js
@@ -101,19 +101,19 @@ const createOrUpdateDataSources = async (appSync, config, debug) => {
     return merge(formattedDataSource, { mode })
   }, defaultToAnArray(config.dataSources))
 
-  return await Promise.all(
-    map(async (dataSource) => {
-      const params = pickExcluded(['mode'], dataSource)
-      if (equals(dataSource.mode, 'create')) {
-        debug(`Creating data source ${params.name}`)
-        await appSync.createDataSource(params).promise()
-      } else if (equals(dataSource.mode, 'update')) {
-        debug(`Updating data source ${params.name}`)
-        await appSync.updateDataSource(params).promise()
-      }
-      return Promise.resolve(dataSource)
-    }, dataSourcesToDeploy)
-  )
+  const res = []
+  for (const dataSource of dataSourcesToDeploy) {
+    const params = pickExcluded(['mode'], dataSource)
+    if (equals(dataSource.mode, 'create')) {
+      debug(`Creating data source ${params.name}`)
+      await appSync.createDataSource(params).promise()
+    } else if (equals(dataSource.mode, 'update')) {
+      debug(`Updating data source ${params.name}`)
+      await appSync.updateDataSource(params).promise()
+    }
+    res.push(dataSource)
+  }
+  return res
 }
 
 /**

--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -72,28 +72,28 @@ const createOrUpdateResolvers = async (appSync, config, debug) => {
     return merge(resolver, { mode })
   }, resolversWithTemplates)
 
-  return await Promise.all(
-    map(async (resolver) => {
-      const params = {
-        apiId: config.apiId,
-        fieldName: resolver.field,
-        requestMappingTemplate: resolver.requestMappingTemplate,
-        responseMappingTemplate: resolver.responseMappingTemplate,
-        typeName: resolver.type,
-        dataSourceName: resolver.dataSource,
-        kind: resolver.kind,
-        pipelineConfig: resolver.pipelineConfig
-      }
-      if (equals(resolver.mode, 'create')) {
-        debug(`Creating resolver ${resolver.field}/${resolver.type}`)
-        await appSync.createResolver(params).promise()
-      } else if (equals(resolver.mode, 'update')) {
-        debug(`Updating resolver ${resolver.field}/${resolver.type}`)
-        await appSync.updateResolver(params).promise()
-      }
-      return Promise.resolve(resolver)
-    }, resolversToDeploy)
-  )
+  const res = []
+  for (const resolver of resolversToDeploy) {
+    const params = {
+      apiId: config.apiId,
+      fieldName: resolver.field,
+      requestMappingTemplate: resolver.requestMappingTemplate,
+      responseMappingTemplate: resolver.responseMappingTemplate,
+      typeName: resolver.type,
+      dataSourceName: resolver.dataSource,
+      kind: resolver.kind,
+      pipelineConfig: resolver.pipelineConfig
+    }
+    if (equals(resolver.mode, 'create')) {
+      debug(`Creating resolver ${resolver.field}/${resolver.type}`)
+      await appSync.createResolver(params).promise()
+    } else if (equals(resolver.mode, 'update')) {
+      debug(`Updating resolver ${resolver.field}/${resolver.type}`)
+      await appSync.updateResolver(params).promise()
+    }
+    res.push(resolver)
+  }
+  return res
 }
 
 /**


### PR DESCRIPTION
when making more than one change to the `serverless.yml` schema at a time (or even freshly deploying a ton of resolvers or data sources), the code throws the exception:

```
ConcurrentModificationException: Schema is currently being altered, please wait until that is complete.
```

this is because the schema cannot be processing more than 1 update request at a time. so we have to do this linearly. `await Promise.all(...)` will send a update request concurrently for all items in the array.

without this fix, we can't bootstrap appsync apis from 0 to 1 (eg. migrate an existing appsync api interfaced by aws-amplify to being interfaced by serverless components)