### PR TITLE
Removed request mapping extraneous character

### DIFF
--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -46,7 +46,7 @@ const createOrUpdateResolvers = async (appSync, config, debug) => {
         if (equals(dataSource.type, 'AWS_LAMBDA')) {
           requestMappingTemplate =
             requestMappingTemplate ||
-            '{ "version": "2017-02-28", "operation": "Invoke", "payload": $util.toJson($context.arguments) })'
+            '{ "version": "2017-02-28", "operation": "Invoke", "payload": $util.toJson($context.arguments) }'
           responseMappingTemplate = responseMappingTemplate || '$util.toJson($context.result)'
         }
       }


### PR DESCRIPTION
The default request mapping template for Lambda function datasources has an extraneous character, resulting in an error out of the box (`Trailing characters at the end of the JSON string are not allowed.`)

Fixes https://github.com/serverless-components/aws-app-sync/issues/25 🔧 