### PR TITLE
Returns an empty array if there's not a data source type match.

### DIFF
--- a/lib/role.js
+++ b/lib/role.js
@@ -151,7 +151,7 @@ const createServiceRole = async (awsIamRole, config, debug) => {
             }
           ]
         default:
-          break
+          return []
       }
     }),
     flatten


### PR DESCRIPTION
Supports the case where the data source type doesn't need to be explicitly handled and a role is not required (like HTTP).

This assumes that we're okay with handling unspecified data sources by assuming that they don't need a policy.  Otherwise it may be better to explicitly handle HTTP by returning an empty array and throw if it reaches default.

With out this change I was getting statements as [undefined] and sometimes [null] from the pipe break -> flatten. 